### PR TITLE
Feature/cor 941 automateupdate workflows upload

### DIFF
--- a/.github/workflows/add_colab_link.yml
+++ b/.github/workflows/add_colab_link.yml
@@ -72,8 +72,8 @@ jobs:
         uses: tj-actions/changed-files@v19
         with:
           quotepath: "false"
-          use_fork_point: "true"
-          #since_last_remote_commit: "true"
+          # use_fork_point: "true"
+          since_last_remote_commit: "true"
           files: |
             **/*.ipynb
 

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -29,10 +29,6 @@ jobs:
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
         fi
 
-        export ENVIRONMENT="development"
-        export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-        export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
         echo "##[set-output name=environment;]$(echo $ENVIRONMENT)"
         echo "::set-output name=aws_access_key_id::$(echo $AWS_ACCESS_KEY_ID)"
         echo "::set-output name=aws_secret_access_key::$(echo $AWS_SECRET_ACCESS_KEY)"

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set Github env var based on branch name
       id: set-environment
       run: |
-        BRANCH_NAME=${{ github.ref_name }}
+        BRANCH_NAME=${{ github.head_ref }}
         echo $BRANCH_NAME
         if [[ $BRANCH_NAME == "main" ]]; then
           export ENVIRONMENT="production"

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -40,8 +40,12 @@ jobs:
         aws-secret-access-key: ${{ steps.set-environment.outputs.aws_secret_access_key }}
         aws-region: ${{ secrets.AWS_REGION }}
 
+
     - name: Upload to S3
       run: |
+        ENVIRONMENT=${{ steps.set-environment.outputs.environment }}
+        echo "Uploading notebooks to S3"
+
         aws s3 cp workflows s3://relevance-${ENVIRONMENT}-ap-southeast-2-workflows/workflows/notebooks/ --recursive
 
         if [[ $ENVIRONMENT == "prod" ]]; then

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -34,7 +34,6 @@ jobs:
         export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
         echo "##[set-output name=environment;]$(echo $ENVIRONMENT)"
-        echo "::set-output name=short-sha::$(git rev-parse --short ${{ github.sha }})"
         echo "::set-output name=aws_access_key_id::$(echo $AWS_ACCESS_KEY_ID)"
         echo "::set-output name=aws_secret_access_key::$(echo $AWS_SECRET_ACCESS_KEY)"
 

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -24,7 +24,7 @@ jobs:
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
         elif [[ $BRANCH_NAME == "development" ]]; then
-          export ENVIRONMENT="dev"
+          export ENVIRONMENT="development"
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
         fi

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -37,12 +37,13 @@ jobs:
         echo "::set-output name=aws_access_key_id::$(echo $AWS_ACCESS_KEY_ID)"
         echo "::set-output name=aws_secret_access_key::$(echo $AWS_SECRET_ACCESS_KEY)"
 
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ steps.set-environment.outputs.aws_access_key_id }}
         aws-secret-access-key: ${{ steps.set-environment.outputs.aws_secret_access_key }}
-        aws-region: ${{ matrix.region }}
+        aws-region: ${{ secrets.AWS_REGION }}
 
     - name: Upload to S3
       run: |

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -20,15 +20,18 @@ jobs:
         BRANCH_NAME=${{ github.head_ref }}
         echo $BRANCH_NAME
         if [[ $BRANCH_NAME == "main" ]]; then
-          export ENVIRONMENT="production"
+          export ENVIRONMENT="prod"
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
         elif [[ $BRANCH_NAME == "development" ]]; then
-          export ENVIRONMENT="development"
+          export ENVIRONMENT="dev"
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-        echo $ENVIRONMENT
+        export ENVIRONMENT="dev"
+        export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+        export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
         echo "##[set-output name=environment;]$(echo $ENVIRONMENT)"
         echo "::set-output name=aws_access_key_id::$(echo $AWS_ACCESS_KEY_ID)"
         echo "::set-output name=aws_secret_access_key::$(echo $AWS_SECRET_ACCESS_KEY)"

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -5,7 +5,6 @@ on:
       branches: [ main, development ]
   pull_request:
 
-
 jobs:
   upload:
     name: Upload to s3
@@ -27,13 +26,12 @@ jobs:
           export ENVIRONMENT="dev"
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        else
-          export ENVIRONMENT="sandbox"
-          export AWS_ACCESS_KEY_ID=${{ secrets.SANDBOX_AWS_ACCESS_KEY_ID }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.SANDBOX_AWS_SECRET_ACCESS_KEY }}
-        fi
+
 
         echo $ENVIRONMENT
+        export ENVIRONMENT="dev"
+        export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+        export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
         echo "##[set-output name=environment;]$(echo $ENVIRONMENT)"
         echo "::set-output name=short-sha::$(git rev-parse --short ${{ github.sha }})"

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -1,0 +1,55 @@
+name: Upload to S3
+
+on:
+  push:
+      branches: [ main, development ]
+  pull_request:
+
+
+jobs:
+  upload:
+    name: Upload to s3
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Set Github env var based on branch name
+      id: set-environment
+      run: |
+        BRANCH_NAME=${{ github.head_ref }}
+        echo $BRANCH_NAME
+        if [[ $BRANCH_NAME == "main" ]]; then
+          export ENVIRONMENT="prod"
+          export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+          export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        elif [[ $BRANCH_NAME == "development" ]]; then
+          export ENVIRONMENT="dev"
+          export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+          export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        else
+          export ENVIRONMENT="sandbox"
+          export AWS_ACCESS_KEY_ID=${{ secrets.SANDBOX_AWS_ACCESS_KEY_ID }}
+          export AWS_SECRET_ACCESS_KEY=${{ secrets.SANDBOX_AWS_SECRET_ACCESS_KEY }}
+        fi
+
+        echo $ENVIRONMENT
+
+        echo "##[set-output name=environment;]$(echo $ENVIRONMENT)"
+        echo "::set-output name=short-sha::$(git rev-parse --short ${{ github.sha }})"
+        echo "::set-output name=aws_access_key_id::$(echo $AWS_ACCESS_KEY_ID)"
+        echo "::set-output name=aws_secret_access_key::$(echo $AWS_SECRET_ACCESS_KEY)"
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ steps.set-environment.outputs.aws_access_key_id }}
+        aws-secret-access-key: ${{ steps.set-environment.outputs.aws_secret_access_key }}
+        aws-region: ${{ matrix.region }}
+
+    - name: Upload to S3
+      run: |
+        aws s3 cp workflows s3://relevance-${ENVIRONMENT}-ap-southeast-2-workflows/workflows/notebooks/ --recursive
+
+        if [[ $ENVIRONMENT == "prod" ]]; then
+          aws s3 cp workflows s3://relevance-${ENVIRONMENT}-us-east-1-workflows/workflows/notebooks/ --recursive

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -27,6 +27,7 @@ jobs:
           export ENVIRONMENT="dev"
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        fi
 
         export ENVIRONMENT="dev"
         export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -7,8 +7,9 @@ on:
 
 jobs:
   upload:
-    name: Upload to s3
+    name: Upload new notebooks to S3
     runs-on: ubuntu-latest
+
     steps:
     - name: Check out code
       uses: actions/checkout@v2
@@ -16,27 +17,21 @@ jobs:
     - name: Set Github env var based on branch name
       id: set-environment
       run: |
-        BRANCH_NAME=${{ github.head_ref }}
+        BRANCH_NAME=${{ github.ref_name }}
         echo $BRANCH_NAME
         if [[ $BRANCH_NAME == "main" ]]; then
-          export ENVIRONMENT="prod"
+          export ENVIRONMENT="production"
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
         elif [[ $BRANCH_NAME == "development" ]]; then
-          export ENVIRONMENT="dev"
+          export ENVIRONMENT="development"
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-
         echo $ENVIRONMENT
-        export ENVIRONMENT="dev"
-        export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-        export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
         echo "##[set-output name=environment;]$(echo $ENVIRONMENT)"
         echo "::set-output name=aws_access_key_id::$(echo $AWS_ACCESS_KEY_ID)"
         echo "::set-output name=aws_secret_access_key::$(echo $AWS_SECRET_ACCESS_KEY)"
-
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -23,7 +23,7 @@ jobs:
           export ENVIRONMENT="prod"
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        elif [[ $BRANCH_NAME == "development" ]]; then
+        else
           export ENVIRONMENT="development"
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -50,3 +50,4 @@ jobs:
 
         if [[ $ENVIRONMENT == "prod" ]]; then
           aws s3 cp workflows s3://relevance-${ENVIRONMENT}-us-east-1-workflows/workflows/notebooks/ --recursive
+        fi

--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -29,7 +29,7 @@ jobs:
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
         fi
 
-        export ENVIRONMENT="dev"
+        export ENVIRONMENT="development"
         export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
         export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
 

--- a/scripts/manual_add_to_db.py
+++ b/scripts/manual_add_to_db.py
@@ -40,12 +40,8 @@ WORKFLOWS = [
         "video_links": [],
         "new": False,
         "prerequisites": ["Uploaded dataset with text or image fields"],
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "vectorize/Vectorize_Your_Data_with_Relevance_AI_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/vectorize/Vectorize_Your_Data_with_Relevance_AI_params.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/vectorize/Vectorize_Your_Data_with_Relevance_AI_params.ipynb",
-        },
     },
     {
         "_id": "core-dr",
@@ -67,12 +63,8 @@ WORKFLOWS = [
         ],
         "new": False,
         "core": True,
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "dr/Reduce_the_Dimensions_of_Your_Data_with_Relevance_AI_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/dr/Reduce_the_Dimensions_of_Your_Data_with_Relevance_AI_params.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/dr/Reduce_the_Dimensions_of_Your_Data_with_Relevance_AI_params.ipynb",
-        },
     },
     {
         "_id": "core-cluster",
@@ -91,12 +83,8 @@ WORKFLOWS = [
         "video_links": [],
         "new": False,
         "prerequisites": ["Vectorised some fields in your data"],
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "cluster/Cluster_Your_Data_with_Relevance_AI_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/cluster/Cluster_Your_Data_with_Relevance_AI_params.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/cluster/Cluster_Your_Data_with_Relevance_AI_params.ipynb",
-        },
     },
     {
         "_id": "core-subclustering",
@@ -114,12 +102,8 @@ WORKFLOWS = [
         "video_links": [],
         "new": False,
         "prerequisites": ["Vectorised text or image fields in your dataset"],
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "subclustering/core_subclustering_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/subclustering/core_subclustering_params.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/subclustering/core_subclustering_params.ipynb",
-        },
     },
     ############### NEW WORKFLOWS
     {
@@ -143,20 +127,15 @@ WORKFLOWS = [
             "List of data items (images/text) to vectorize",
             "Vectorizer",
         ],
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "bias-detection/✨Vector_Based_Bias_Detection_With_Relevance_AI_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/bias-detection/✨Vector_Based_Bias_Detection_With_Relevance_AI_params.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/bias-detection/✨Vector_Based_Bias_Detection_With_Relevance_AI_params.ipynb",
-        },
     },
     {
         "_id": "taxonomy",
         "type": "workflow",
         "title": "Add Taxonomy",
         "description": "Insert your taxonomy into Relevance AI",
-        "colab_link": COLAB_PREFIX
-        + "workflows/taxonomy/Taxonomy.ipynb",
+        "colab_link": COLAB_PREFIX + "workflows/taxonomy/Taxonomy.ipynb",
         "use_cases": ["Label your data with a pre-determined taxonomy."],
         "documentation_links": [
             {
@@ -166,16 +145,9 @@ WORKFLOWS = [
         ],
         "video_links": [],
         "new": True,
-        "prerequisites": [
-            "Taxonomy you would like to insert",
-            "Dataset with text"
-        ],
-        ## workflows-deploy reads notebook_path from these fields
+        "prerequisites": ["Taxonomy you would like to insert", "Dataset with text"],
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "workflows/taxonomy/Taxonomy.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/taxonomy/Taxonomy.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/taxonomy/Taxonomy.ipynb",
-        },
     },
     {
         "_id": "cluster-reports",
@@ -200,12 +172,8 @@ WORKFLOWS = [
         ],
         "video_links": [],
         "new": True,
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "cluster-reporting/👍_Cluster_Reports_With_Relevance_AI_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/cluster-reporting/👍_Cluster_Reports_With_Relevance_AI_params.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/cluster-reporting/👍_Cluster_Reports_With_Relevance_AI_params.ipynb",
-        },
     },
     {
         "_id": "subclustering",
@@ -226,35 +194,27 @@ WORKFLOWS = [
         ],
         "video_links": [],
         "new": True,
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "subclustering/basic_subclustering_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/development/subclustering/basic_subclustering.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/subclustering/basic_subclustering.ipynb",
-        },
     },
     ##### Non core workflows
-#     {
-#         "_id": "impact-analysis",
-#         "type": "workflow",
-#         "colab_link": COLAB_PREFIX + "workflows/impact-analysis/impact-analysis.ipynb",
-#         "title": "Feature/Impact Analysis",
-#         "description": "Analyse the impact of your features and directly assess how important they are and their local/global impact on the KPI or metric.",
-#         "prerequisites": [
-#             "Dataset with encoded vectors and a variable to measure importance."
-#         ],
-#         "use_cases": ["KPI Measurement", "Impact Analysis"],
-#         "documentation_links": [],
-#         "video_links": [],
-#         "new": True,
-#         "coming_soon": False,
-#         ## workflows-deploy reads notebook_path from these fields
-#         "suffix": "impact-analysis/impact-analysis_params.ipynb",
-#         "s3_url": {
-#             "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/impact-analysis/impact-analysis.ipynb",
-#             "stg": "s3://relevanceai-workflows/dev/impact-analysis/impact-analysis.ipynb",
-#         },
-#     },
+    #     {
+    #         "_id": "impact-analysis",
+    #         "type": "workflow",
+    #         "colab_link": COLAB_PREFIX + "workflows/impact-analysis/impact-analysis.ipynb",
+    #         "title": "Feature/Impact Analysis",
+    #         "description": "Analyse the impact of your features and directly assess how important they are and their local/global impact on the KPI or metric.",
+    #         "prerequisites": [
+    #             "Dataset with encoded vectors and a variable to measure importance."
+    #         ],
+    #         "use_cases": ["KPI Measurement", "Impact Analysis"],
+    #         "documentation_links": [],
+    #         "video_links": [],
+    #         "new": True,
+    #         "coming_soon": False,
+    #         ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
+    #         "suffix": "impact-analysis/impact-analysis_params.ipynb"
+    #     },
     {
         "_id": "keyphrases",
         "type": "workflow",
@@ -271,12 +231,8 @@ WORKFLOWS = [
         ],
         "video_links": [],
         "new": False,
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "keyphrases/KeyPhrases_Workflow_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/keyphrases/KeyPhrases_Workflow.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/keyphrases/KeyPhrases_Workflow.ipynb",
-        },
     },
     {
         "_id": "vector-rake",
@@ -292,12 +248,8 @@ WORKFLOWS = [
             "vectorized text field",
             "vectorizer",
         ],
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "vector-rake/vector_rake_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/vector-rake/vector_rake.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/vector-rake/vector_rake.ipynb",
-        },
     },
     {
         "_id": "most-common-words-in-clusters",
@@ -317,12 +269,8 @@ WORKFLOWS = [
         "video_links": [],
         "new": False,
         "coming_soon": False,
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "most-common-words-in-clusters/most-common-words-in-clusters_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/most-common-words-in-clusters/most-common-words-in-clusters.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/most-common-words-in-clusters/most-common-words-in-clusters.ipynb",
-        },
     },
     {
         "_id": "community-detection",
@@ -341,12 +289,8 @@ WORKFLOWS = [
         ],
         "video_links": [],
         "new": True,
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "community-detection/Community_Detection_with_Relevance_AI_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/community-detection/Community_Detection_with_Relevance_AI.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/community-detection/Community_Detection_with_Relevance_AI.ipynb",
-        },
     },
     {
         "_id": "media-upload",
@@ -368,12 +312,8 @@ WORKFLOWS = [
         "video_links": [],
         "new": True,
         "core": False,
-        ## workflows-deploy reads notebook_path from these fields
+        ## https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows `notebook_path` parameter refers to `suffix`
         "suffix": "media_upload/💡_Upload_Audio_Images_Videos_Flow_params.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/media_upload/💡_Upload_Audio_Images_Videos_Flow.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/media_upload/💡_Upload_Audio_Images_Videos_Flow.ipynb",
-        },
     },
     {
         "_id": "sentiment",
@@ -393,11 +333,11 @@ WORKFLOWS = [
         "new": True,
         "core": False,
     },
-
     {
         "_id": "explain-text-clusters",
         "type": "workflow",
-        "colab_link": COLAB_PREFIX + "workflows/explain-text-clusters/explain-text-clusters_form.ipynb",
+        "colab_link": COLAB_PREFIX
+        + "workflows/explain-text-clusters/explain-text-clusters_form.ipynb",
         "title": "Explain text clusters",
         "description": "Explain text clusters",
         "prerequisites": ["Dataset with text field", "Ran clustering workflow"],
@@ -405,7 +345,7 @@ WORKFLOWS = [
         "documentation_links": [
             {
                 "title": "SDK Reference",
-                "url": "https://relevanceai.readthedocs.io/en/development/operations/cluster/explain_text_clusters.html" ,
+                "url": "https://relevanceai.readthedocs.io/en/development/operations/cluster/explain_text_clusters.html",
             }
         ],
         "video_links": [],
@@ -438,7 +378,6 @@ WORKFLOWS = [
         #             "video_links": [],
         #             "new": True,
         "coming_soon": True,
-        # "s3_url": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/keyphrases/KeyPhrases_Workflow.ipynb",
     },
     {
         "_id": "video-search",
@@ -456,7 +395,6 @@ WORKFLOWS = [
         # "video_links": [],
         # "new": True,
         "coming_soon": True,
-        # "s3_url": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/keyphrases/KeyPhrases_Workflow.ipynb",
     },
     ############### RECIPES
     {
@@ -478,10 +416,6 @@ WORKFLOWS = [
         "new": True,
         "core": False,
         "suffix": "dummy-datasets/Dummy_Datasets_Workflow.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/dummy-datasets/Dummy_Datasets_Workflow.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/dummy-datasets/Dummy_Datasets_Workflow.ipynb",
-        },
     },
     {
         "_id": "pdf-search",
@@ -565,10 +499,6 @@ WORKFLOWS = [
         "recipe_url": "https://relevance.ai",
         "logo_url": "https://www.svgrepo.com/show/22159/twitter.svg",
         "suffix": "twitter-analysis/AI_Twitter_Analysis_by_Relevance_AI.ipynb",
-        "s3_url": {
-            "dev": "s3://relevanceai-workflows-701405094693-ap-southeast-2/dev/twitter-analysis/AI_Twitter_Analysis_by_Relevance_AI.ipynb",
-            "stg": "s3://relevanceai-workflows/dev/twitter-analysis/AI_Twitter_Analysis_by_Relevance_AI.ipynb",
-        },
     },
 ]
 


### PR DESCRIPTION
This action uploads the notebooks to it's appropriate S3 bucket location based in ENVIRONMENT determined by the branch name.

Please see the relevant Github action [here](https://github.com/RelevanceAI/workflows/pull/77/files#diff-dbd10ebcaf64520d64c217925afbd40ffa94f5ad7f814380d60d57a5744398ab)

- branch_name=main,  ENVIRONMENT=prod
- branch_name=development,  ENVIRONMENT=dev

and will upload to the appropriate S3 bucket location

-   ENVIRONMENT=prod
[relevance-prod-us-east-1-workflows](https://s3.console.aws.amazon.com/s3/buckets/relevance-prod-us-east-1-workflows?region=ap-southeast-2)

-   ENVIRONMENT=dev
[relevance-dev-us-east-1-workflows](https://s3.console.aws.amazon.com/s3/buckets/relevance-dev-us-east-1-workflows?region=ap-southeast-2)

This in turn updates the notebooks triggered in the 'Cloud Run' automation workflow in the dashboard.

These notebooks are what the Workflows API initiates and processes in [`sagemaker-run-notebook`](https://github.com/RelevanceAI/sagemaker-run-notebook/) - ref [here](https://api-dev.ap-southeast-2.relevance.ai/latest/documentation#tag/workflows)
https://api.us-east-1.relevance.ai/latest/workflows/trigger

Request Payload
```
{
    "params": { },
    "notebook_path": "string",
    "instance_type": "string"
}
```
params map to cell with `parameters` tag

![image](https://user-images.githubusercontent.com/12078186/172297255-6912d400-a2bc-46c6-a131-4a4f9e1017ba.png)

`notebook_path` maps to [`suffix` in the `workflows-recipes` dataset](https://github.com/RelevanceAI/workflows/blob/13ef692345c20f51adc20edcdf935d323638448b/scripts/manual_add_to_db.py#L95)

Please remember to update the [execution container requirements](https://github.com/RelevanceAI/sagemaker-run-notebook/blob/development/container/requirements.txt) and rebuild/push the execution container image in sagemaker-run-notebook for the Sagemaker Processing job if we change notebook dependencies in core workflows eg. update SDK version to support new feature. The CICD has been set up to build/push on `development` and `master` to the appropriate environment infra. 

Since dashboard is connected to prod API - need to push to master to update dashboard. Integration testing should be done on dev.

![image](https://user-images.githubusercontent.com/12078186/172297922-b40021e7-c7da-45be-aad3-59965fc2698e.png)




