### PR TITLE
New bucket naming for production upload

### DIFF
--- a/.github/workflows/upload_s3.yml
+++ b/.github/workflows/upload_s3.yml
@@ -35,8 +35,8 @@ jobs:
       run: |
         echo $BRANCH_NAME
         if [[ $BRANCH_NAME == "main" ]]; then
-          aws s3 cp workflows s3://relevance-prod-ap-southeast-2-workflows/workflows/notebooks/ --recursive
-          aws s3 cp workflows s3://relevance-prod-us-east-1-workflows/workflows/notebooks/ --recursive
+          aws s3 cp workflows s3://relevance-production-ap-southeast-2-workflows/workflows/notebooks/ --recursive
+          aws s3 cp workflows s3://relevance-production-us-east-1-workflows/workflows/notebooks/ --recursive
         else
           aws s3 cp workflows s3://relevance-development-ap-southeast-2-workflows/workflows/notebooks/ --recursive
         fi


### PR DESCRIPTION
We rolled out a change in TF to move to long environment name convention, so workflow buckets are now named `relevance-production-*-workflows`. I updated corresponding [github IAM policy](https://us-east-1.console.aws.amazon.com/iam/home#/users/github$policyEditor?policyName=workflows-s3-upload&step=edit) to add those patterns.

Rel: https://linear.app/relevance/issue/COR-954/production-deployment